### PR TITLE
学習，テストループをfor文を使って一体化させた

### DIFF
--- a/scripts/mnist_bc.py
+++ b/scripts/mnist_bc.py
@@ -47,10 +47,10 @@ def main():
         accuracy = [0, 0]
         for i, mode in enumerate(['train', 'test']):
             if mode == 'train':
-                # 学習開始
+                # モデルを学習モードにする
                 model.train()
             else:
-                # 学習のストップ
+                # モデルを推論モードにする
                 model.eval()
             for inputs, labels in loaders[mode]:
                 # 指定したdeviceに変数を変換

--- a/scripts/mnist_bc.py
+++ b/scripts/mnist_bc.py
@@ -40,42 +40,19 @@ def main():
         'test_acc': [],
     }
     # 学習，テスト用ループ
-    for epoch in range(epochs):
-        # 学習開始
-        model.train()
-        train_loss = 0
-        train_correct = 0
-        train_data_num = 0
-        for inputs, labels in loaders['train']:
-            # 指定したdeviceに変数を変換
-            inputs = inputs.to(device)
-            labels = labels.to(device)
-            # データの整形
-            inputs = inputs.view(-1, 28 * 28)
-            # ニューラルネットワークへのデータ入力
-            outputs = model(inputs)
-            # 誤差を算出
-            loss = criterion(outputs, labels)
-            train_loss += loss.item()
-            # 誤差逆伝搬とパラメーターの更新
-            optimizer.zero_grad()
-            loss.backward()
-            model.set_grad()
-            optimizer.step()
-            # 正解数を求める
-            outputs = torch.argmax(outputs, dim=1)
-            train_correct += torch.sum(outputs == labels).item()
-            # 総データ数を求める
-            train_data_num += labels.shape[0]
-    
-        # テストパート
-        # 学習のストップ
-        model.eval()
-        test_loss = 0
-        test_correct = 0
-        test_data_num = 0
-        with torch.no_grad():
-            for inputs, labels in loaders['test']:
+    for epoch in  range(epochs):
+        losses = [0, 0]
+        corrects = [0, 0]
+        data_nums = [0 , 0]
+        accuracy = [0, 0]
+        for i, mode in enumerate(['train', 'test']):
+            if mode == 'train':
+                # 学習開始
+                model.train()
+            else:
+                # 学習のストップ
+                model.eval()
+            for inputs, labels in loaders[mode]:
                 # 指定したdeviceに変数を変換
                 inputs = inputs.to(device)
                 labels = labels.to(device)
@@ -84,33 +61,38 @@ def main():
                 # ニューラルネットワークへのデータ入力
                 outputs = model(inputs)
                 # 誤差を算出
-                test_loss += criterion(outputs, labels).item()
+                loss = criterion(outputs, labels)
+                losses[i] += loss.item()
+                if mode == 'train':
+                    # 誤差逆伝搬とパラメーターの更新
+                    optimizer.zero_grad()
+                    loss.backward()
+                    model.set_grad()
+                    optimizer.step()
                 # 正解数を求める
                 outputs = torch.argmax(outputs, dim=1)
-                test_correct += torch.sum(outputs == labels).item()
+                corrects[i] += torch.sum(outputs == labels).item()
                 # 総データ数を求める
-                test_data_num += labels.shape[0]
-                
-        # 平均誤差を算出
-        train_loss /= train_data_num
-        test_loss /= test_data_num
-        train_correct /= train_data_num
-        test_correct /= test_data_num
-        # 1エポックあたりの誤差と正解率を表示
-        print('epoch: {} Train loss (avg): {}, Accuracy: {}'.format(epoch + 1, train_loss, train_correct))
-        print('epoch: {} Test loss (avg): {}, Accuracy: {}'.format(epoch + 1, test_loss, test_correct))
+                data_nums[i] += labels.shape[0]
+            # 平均誤差を算出
+            losses[i] /= data_nums[i]
+            accuracy[i] = corrects[i] / data_nums[i]
+            # 誤差と正解率を代入
+            history[mode + '_loss'].append(losses[i])
+            history[mode + '_acc'].append(accuracy[i])
+            
+        # 誤差と正解率を表示
+        print('epoch: {} Train loss (avg): {}, Accuracy: {}'.format(epoch + 1, losses[0], accuracy[0]))
+        print('epoch: {} Test loss (avg): {}, Accuracy: {}'.format(epoch + 1, losses[1], accuracy[1]))
+        
+        # グラフ造形用にエポック数を追加
+        history['epoch'].append(epoch + 1)
+        
         # print(model.fc1.weight.data)
-        print(model.fc2.weight.data)
+        # print(model.fc2.weight.data)
         # print(model.fc1_bc.weight.data)
         # print(model.fc2_bc.weight.data)
-
-        # 誤差と正解率を代入
-        history['train_loss'].append(train_loss)
-        history['train_acc'].append(train_correct)
-        history['test_loss'].append(test_loss)
-        history['test_acc'].append(test_correct)
-        history['epoch'].append(epoch + 1)
-
+        
     # 正答率,誤差のグラフを出力
     functions.make_fig(history)
     

--- a/scripts/mnist_bc.py
+++ b/scripts/mnist_bc.py
@@ -40,10 +40,10 @@ def main():
         'test_acc': [],
     }
     # 学習，テスト用ループ
-    for epoch in  range(epochs):
+    for epoch in range(epochs):
         losses = [0, 0]
         corrects = [0, 0]
-        data_nums = [0 , 0]
+        data_nums = [0, 0]
         accuracy = [0, 0]
         for i, mode in enumerate(['train', 'test']):
             if mode == 'train':

--- a/scripts/mnist_mlp.py
+++ b/scripts/mnist_mlp.py
@@ -41,40 +41,18 @@ def main():
     }
     # 学習，テスト用ループ
     for epoch in range(epochs):
-        # 学習開始
-        model.train()
-        train_loss = 0
-        train_correct = 0
-        train_data_num = 0
-        for inputs, labels in loaders['train']:
-            # 指定したdeviceに変数を変換
-            inputs = inputs.to(device)
-            labels = labels.to(device)
-            # データの整形
-            inputs = inputs.view(-1, 28 * 28)
-            # ニューラルネットワークへのデータ入力
-            outputs = model(inputs)
-            # 誤差を算出
-            loss = criterion(outputs, labels)
-            train_loss += loss.item()
-            # 誤差逆伝搬とパラメーターの更新
-            optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
-            # 正解数を求める
-            outputs = torch.argmax(outputs, dim=1)
-            train_correct += torch.sum(outputs == labels).item()
-            # 総データ数を求める
-            train_data_num += labels.shape[0]
-    
-        # テストパート
-        # 学習のストップ
-        model.eval()
-        test_loss = 0
-        test_correct = 0
-        test_data_num = 0
-        with torch.no_grad():
-            for inputs, labels in loaders['test']:
+        losses = [0, 0]
+        corrects = [0, 0]
+        data_nums = [0, 0]
+        accuracy = [0, 0]
+        for i, mode in enumerate(['train', 'test']):
+            if mode == 'train':
+                # 学習開始
+                model.train()
+            else:
+                # 学習終了
+                model.eval()
+            for inputs, labels in loaders[mode]:
                 # 指定したdeviceに変数を変換
                 inputs = inputs.to(device)
                 labels = labels.to(device)
@@ -83,28 +61,30 @@ def main():
                 # ニューラルネットワークへのデータ入力
                 outputs = model(inputs)
                 # 誤差を算出
-                test_loss += criterion(outputs, labels).item()
+                loss = criterion(outputs, labels)
+                losses[i] += loss.item()
+                if mode == 'train':
+                    # 誤差逆伝搬とパラメーターの更新
+                    optimizer.zero_grad()
+                    loss.backward()
+                    optimizer.step()
                 # 正解数を求める
                 outputs = torch.argmax(outputs, dim=1)
-                test_correct += torch.sum(outputs == labels).item()
+                corrects[i] += torch.sum(outputs == labels).item()
                 # 総データ数を求める
-                test_data_num += labels.shape[0]
+                data_nums[i] += labels.shape[0]
                 
-        # 平均誤差を算出
-        train_loss /= train_data_num
-        test_loss /= test_data_num
-        train_correct /= train_data_num
-        test_correct /= test_data_num
+            # 平均誤差を算出
+            losses[i] /= data_nums[i]
+            accuracy[i] = corrects[i] / data_nums[i]
+            # 誤差と正解率を代入
+            history[mode + '_loss'].append(losses[i])
+            history[mode + '_acc'].append(accuracy[i])
         # 1エポックあたりの誤差と正解率を表示
-        print('epoch{} Train loss (avg): {}, Accuracy: {}'.format(epoch + 1, train_loss, train_correct))
-        print('epoch{} Test loss (avg): {}, Accuracy: {}'.format(epoch + 1, test_loss, test_correct))
-        print(model.fc2.weight.data)
+        print('epoch: {} Train loss (avg): {}, Accuracy: {}'.format(epoch + 1, losses[0], accuracy[0]))
+        print('epoch: {} Test loss (avg): {}, Accuracy: {}'.format(epoch + 1, losses[1], accuracy[1]))
+        # print(model.fc2.weight.data)
 
-        # 誤差と正解率を代入
-        history['train_loss'].append(train_loss)
-        history['train_acc'].append(train_correct)
-        history['test_loss'].append(test_loss)
-        history['test_acc'].append(test_correct)
         history['epoch'].append(epoch + 1)
 
     # 結果の出力と描画

--- a/scripts/mnist_mlp.py
+++ b/scripts/mnist_mlp.py
@@ -47,10 +47,10 @@ def main():
         accuracy = [0, 0]
         for i, mode in enumerate(['train', 'test']):
             if mode == 'train':
-                # 学習開始
+                # モデルを学習モードにする
                 model.train()
             else:
-                # 学習終了
+                # モデルを推論モードにする
                 model.eval()
             for inputs, labels in loaders[mode]:
                 # 指定したdeviceに変数を変換

--- a/scripts/networks.py
+++ b/scripts/networks.py
@@ -7,13 +7,13 @@ class MLPCls(torch.nn.Module):
         # ネットワークの定義
         super(MLPCls, self).__init__()
         self.fc1 = torch.nn.Linear(28 * 28, 1000)
-        self.bc = torch.nn.BatchNorm1d(1000)
+        self.bn = torch.nn.BatchNorm1d(1000)
         self.fc2 = torch.nn.Linear(1000, 10)
         
     # 順伝搬
     def forward(self, x):
         x = self.fc1(x)
-        x = self.bc(x)
+        x = self.bn(x)
         x = torch.relu(x)
         x = self.fc2(x)
         
@@ -24,7 +24,7 @@ class BCCls(torch.nn.Module):
         # ネットワークの定義
         super(BCCls, self).__init__()
         self.fc1 = torch.nn.Linear(28 * 28, 1000)
-        self.bc = torch.nn.BatchNorm1d(1000)
+        self.bn = torch.nn.BatchNorm1d(1000)
         self.fc2 = torch.nn.Linear(1000, 10)
         self.fc1_bc = copy.deepcopy(self.fc1)
         self.fc2_bc = copy.deepcopy(self.fc2)
@@ -33,7 +33,7 @@ class BCCls(torch.nn.Module):
     def forward(self, x):
         BCCls.binarize(self)
         x = self.fc1_bc(x)
-        x = self.bc(x)
+        x = self.bn(x)
         x = torch.relu(x)
         x = self.fc2_bc(x)
         

--- a/scripts/networks.py
+++ b/scripts/networks.py
@@ -7,12 +7,14 @@ class MLPCls(torch.nn.Module):
         # ネットワークの定義
         super(MLPCls, self).__init__()
         self.fc1 = torch.nn.Linear(28 * 28, 1000)
+        self.bc = torch.nn.BatchNorm1d(1000)
         self.fc2 = torch.nn.Linear(1000, 10)
         
     # 順伝搬
     def forward(self, x):
         x = self.fc1(x)
-        x = torch.sigmoid(x)
+        x = self.bc(x)
+        x = torch.relu(x)
         x = self.fc2(x)
         
         return x

--- a/scripts/networks.py
+++ b/scripts/networks.py
@@ -1,5 +1,6 @@
 # import modules
 import torch
+import copy
 
 class MLPCls(torch.nn.Module):
     def __init__(self):
@@ -23,8 +24,8 @@ class BCCls(torch.nn.Module):
         self.fc1 = torch.nn.Linear(28 * 28, 1000)
         self.bc = torch.nn.BatchNorm1d(1000)
         self.fc2 = torch.nn.Linear(1000, 10)
-        self.fc1_bc = torch.nn.Linear(28 * 28, 1000)
-        self.fc2_bc = torch.nn.Linear(1000, 10)
+        self.fc1_bc = copy.deepcopy(self.fc1)
+        self.fc2_bc = copy.deepcopy(self.fc2)
         
     # 順伝搬
     def forward(self, x):


### PR DESCRIPTION
学習ループ，テストループを以下のように修正した
```
# 学習，テスト用ループ
    for epoch in  range(epochs):
        losses = [0, 0]
        corrects = [0, 0]
        data_nums = [0 , 0]
        accuracy = [0, 0]
        for i, mode in enumerate(['train', 'test']):
            if mode == 'train':
                # 学習開始
                model.train()
            else:
                # 学習のストップ
                model.eval()
            for inputs, labels in loaders[mode]:
                # 指定したdeviceに変数を変換
                inputs = inputs.to(device)
                labels = labels.to(device)
                # データの整形
                inputs = inputs.view(-1, 28 * 28)
                # ニューラルネットワークへのデータ入力
                outputs = model(inputs)
                # 誤差を算出
                loss = criterion(outputs, labels)
                losses[i] += loss.item()
                if mode == 'train':
                    # 誤差逆伝搬とパラメーターの更新
                    optimizer.zero_grad()
                    loss.backward()
                    model.set_grad()
                    optimizer.step()
                # 正解数を求める
                outputs = torch.argmax(outputs, dim=1)
                corrects[i] += torch.sum(outputs == labels).item()
                # 総データ数を求める
                data_nums[i] += labels.shape[0]
            # 平均誤差を算出
            losses[i] /= data_nums[i]
            accuracy[i] = corrects[i] / data_nums[i]
            # 誤差と正解率を代入
            history[mode + '_loss'].append(losses[i])
            history[mode + '_acc'].append(accuracy[i])
            
        # 誤差と正解率を表示
        print('epoch: {} Train loss (avg): {}, Accuracy: {}'.format(epoch + 1, losses[0], accuracy[0]))
        print('epoch: {} Test loss (avg): {}, Accuracy: {}'.format(epoch + 1, losses[1], accuracy[1]))
        
        # グラフ造形用にエポック数を追加
        history['epoch'].append(epoch + 1)
```